### PR TITLE
 Fix a semicolon error in linear-regression-scratch.md

### DIFF
--- a/chapter_deep-learning-basics/linear-regression-scratch.md
+++ b/chapter_deep-learning-basics/linear-regression-scratch.md
@@ -49,7 +49,7 @@ def set_figsize(figsize=(3.5, 2.5)):
     plt.rcParams['figure.figsize'] = figsize
 
 set_figsize()
-plt.scatter(features[:, 1].asnumpy(), labels.asnumpy(), 1);
+plt.scatter(features[:, 1].asnumpy(), labels.asnumpy(), 1)
 ```
 
 我们将上面的`plt`作图函数以及`use_svg_display`函数和`set_figsize`函数定义在`d2lzh`包里。以后在作图时，我们将直接调用`d2lzh.plt`。由于`plt`在`d2lzh`包中是一个全局变量，我们在作图前只需要调用`d2lzh.set_figsize()`即可打印矢量图并设置图的尺寸。


### PR DESCRIPTION
I think here is a tiny error that author mix up python with other languages by mistake.