### PR TITLE
fix a mistake in  L2 decay function

### DIFF
--- a/chapter_deep-learning-basics/weight-decay.md
+++ b/chapter_deep-learning-basics/weight-decay.md
@@ -73,7 +73,7 @@ def init_params():
 
 ```{.python .input  n=6}
 def l2_penalty(w):
-    return (w**2).sum() / 2
+    return (w**2).sum() / 20
 ```
 
 ### 定义训练和测试


### PR DESCRIPTION
L2 正则化应该是除样本数 例子里面样本数是20 代码里面却是2
  
    def l2_penalty(w):
    return (w**2).sum() / 2

按道理应该是

    def l2_penalty(w):
    return (w**2).sum() / 20
