### PR TITLE
Fix Python syntax error in setup_origin.py

### DIFF
--- a/setup_origin.py
+++ b/setup_origin.py
@@ -1,7 +1,9 @@
+"""
 ---
 source: https://github.com/d2l-ai/d2l-en/blob/master/setup.py
 commit: 9e55a9c
 ---
+"""
 
 from setuptools import setup, find_packages
 import d2l


### PR DESCRIPTION
% `flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics`
```
./d2l-zh/setup_origin.py:3:13: E999 SyntaxError: invalid decimal literal
commit: 9e55a9c
            ^
./d2l-zh/d2l/tensorflow.py:727:18: F821 undefined name 'get_params'
        params = get_params(len(vocab), num_hiddens)
                 ^
1     E999 SyntaxError: invalid decimal literal
1     F821 undefined name 'get_params'
2
```