### PR TITLE
BUG: Fix BLEU calculation

### DIFF
--- a/chapter_recurrent-modern/seq2seq.md
+++ b/chapter_recurrent-modern/seq2seq.md
@@ -855,11 +855,11 @@ def bleu(pred_seq, label_seq, k):  #@save
     for n in range(1, k + 1):
         num_matches, label_subs = 0, collections.defaultdict(int)
         for i in range(len_label - n + 1):
-            label_subs[''.join(label_tokens[i: i + n])] += 1
+            label_subs[' '.join(label_tokens[i: i + n])] += 1
         for i in range(len_pred - n + 1):
-            if label_subs[''.join(pred_tokens[i: i + n])] > 0:
+            if label_subs[' '.join(pred_tokens[i: i + n])] > 0:
                 num_matches += 1
-                label_subs[''.join(pred_tokens[i: i + n])] -= 1
+                label_subs[' '.join(pred_tokens[i: i + n])] -= 1
         score *= math.pow(num_matches / (len_pred - n + 1), math.pow(0.5, n))
     return score
 ```


### PR DESCRIPTION
Mirroring https://github.com/d2l-ai/d2l-en/pull/1981.

Question: I'm not sure why d2l-zh has no saved `bleu` function in the d2l package even though we have added #@save in the notebook. Any ideas @goldmermaid? Hence I only fixed the notebook code for this, but in the English version the libraries were also updated.