### PR TITLE
fix typo in tensorflow code

### DIFF
--- a/chapter_attention-mechanisms/attention-scoring-functions.md
+++ b/chapter_attention-mechanisms/attention-scoring-functions.md
@@ -170,7 +170,7 @@ masked_softmax(torch.rand(2, 2, 4), d2l.tensor([[1, 3], [2, 4]]))
 
 ```{.python .input}
 #@tab tensorflow
-masked_softmax(tf.random.uniform(shape=(2, 2, 4)), tf.constant([2, 3]))
+masked_softmax(tf.random.uniform(shape=(2, 2, 4)), tf.constant([[1, 3], [2, 4]]))
 ```
 
 ## [**加性注意力**]


### PR DESCRIPTION
changed `tf.constant([2, 3]))` to `tf.constant([[1, 3], [2, 4]]))` to align with pytorch and mxnet code