### PR TITLE
Correct a translation error.

### DIFF
--- a/chapter_computer-vision/image-augmentation.md
+++ b/chapter_computer-vision/image-augmentation.md
@@ -203,7 +203,7 @@ test_augs = torchvision.transforms.Compose([
 ```
 
 :begin_tab:`mxnet`
-接下来，我们定义了一个辅助函数，以便于读取图像和应用图像增广。Gluon的dataset类提供的`transform_first`函数将图像增广应用于每个训练样本的第一个元素（由图像和标签组成），即应用在图像上。有关`DataLoader`的详细介绍，请参阅 :numref:`sec_fashion_mnist`。
+接下来，我们定义了一个辅助函数，以便于读取图像和应用图像增广。Gluon的`dataset`类提供的`transform_first`函数将图像增广应用于每个训练样本的第一个元素（由图像和标签组成），即应用在图像上。有关`DataLoader`的详细介绍，请参阅 :numref:`sec_fashion_mnist`。
 :end_tab:
 
 :begin_tab:`pytorch`

--- a/chapter_computer-vision/image-augmentation.md
+++ b/chapter_computer-vision/image-augmentation.md
@@ -203,7 +203,7 @@ test_augs = torchvision.transforms.Compose([
 ```
 
 :begin_tab:`mxnet`
-接下来，我们定义了一个辅助函数，以便于读取图像和应用图像增广。Gluon数据集提供的`transform_first`函数将图像增广应用于每个训练示例的第一个元素（图像和标签），即图像顶部的元素。有关`DataLoader`的详细介绍，请参阅 :numref:`sec_fashion_mnist`。
+接下来，我们定义了一个辅助函数，以便于读取图像和应用图像增广。Gluon的dataset类提供的`transform_first`函数将图像增广应用于每个训练样本的第一个元素（由图像和标签组成），即应用在图像上。有关`DataLoader`的详细介绍，请参阅 :numref:`sec_fashion_mnist`。
 :end_tab:
 
 :begin_tab:`pytorch`


### PR DESCRIPTION
I have found two problems.
1. the translation "Gluon数据集提供的`transform_first`函数" can be difficult to understand. If the reader does not think carefully, they will not realise that this function is a method of the `Dataset` class, but rather that one of the datasets of `Gluon` contains this function.
2. "即图像顶部的元素" is obviously a wrong translation, it means "i.e. the element at the top of the image.".