### PR TITLE
DEV: Specify cuda10.2 for mxnet

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -186,7 +186,7 @@ github_repo = mxnet, d2l-ai/d2l-zh-colab
 
 replace_svg_url = img, http://d2l.ai/_images
 
-libs = mxnet, mxnet, -U mxnet-cu101==1.7.0
+libs = mxnet, mxnet, -U mxnet-cu102==1.7.0
        mxnet, d2l, git+https://github.com/d2l-ai/d2l-zh@release  # installing d2l
        pytorch, d2l, git+https://github.com/d2l-ai/d2l-zh@release  # installing d2l
        tensorflow, d2l, git+https://github.com/d2l-ai/d2l-zh@release  # installing d2l
@@ -202,7 +202,7 @@ kernel = mxnet, conda_mxnet_p36
          pytorch, conda_pytorch_p36
          tensorflow, conda_tensorflow_p36
 
-libs = mxnet, mxnet, -U mxnet-cu101==1.7.0
+libs = mxnet, mxnet, -U mxnet-cu102==1.7.0
        mxnet, d2l, ..  # installing d2l
        pytorch, d2l, .. # installing d2l
        tensorflow, d2l, .. # installing d2l


### PR DESCRIPTION
I'm not sure why we have mxnet twice. It should be Cuda 10.2 now. Should we get completely rid of these two lines?