### PR TITLE
[Paddle] Fix missing d2l lib for paddle

### DIFF
--- a/chapter_preface/index.md
+++ b/chapter_preface/index.md
@@ -125,6 +125,13 @@ import numpy as np
 import tensorflow as tf
 ```
 
+```{.python .input}
+#@tab paddle
+#@save
+import numpy as np
+import paddle
+```
+
 ### 目标受众
 
 本书面向学生（本科生或研究生）、工程师和研究人员，他们希望扎实掌握深度学习的实用技术。因为我们从头开始解释每个概念，所以不需要过往的深度学习或机器学习背景。全面解释深度学习的方法需要一些数学和编程，但我们只假设你了解一些基础知识，包括线性代数、微积分、概率和非常基础的Python编程。此外，在附录中，我们提供了本书所涵盖的大多数数学知识的复习。大多数时候，我们会优先考虑直觉和想法，而不是数学的严谨性。有许多很棒的书可以引导感兴趣的读者走得更远。Bela Bollobas的《线性分析》 :cite:`Bollobas.1999` 对线性代数和函数分析进行了深入的研究。 :cite:`Wasserman.2013` 是一本很好的统计学指南。如果你以前没有使用过Python语言，那么你可能想要仔细阅读这个[Python教程](http://learnpython.org/)。

--- a/d2l/__init__.py
+++ b/d2l/__init__.py
@@ -5,6 +5,7 @@ Please import d2l by one of the following ways:
 from d2l import mxnet as d2l  # Use MXNet as the backend
 from d2l import torch as d2l  # Use PyTorch as the backend
 from d2l import tensorflow as d2l  # Use TensorFlow as the backend
+from d2l import paddle as d2l  # Use Paddle as the backend
 
 """
 

--- a/d2l/paddle.py
+++ b/d2l/paddle.py
@@ -1,0 +1,26 @@
+#################   WARNING   ################
+# The below part is generated automatically through:
+#    d2lbook build lib
+# Don't edit it directly
+
+import collections
+import hashlib
+import math
+import os
+import random
+import re
+import shutil
+import sys
+import tarfile
+import time
+import zipfile
+from collections import defaultdict
+import pandas as pd
+import requests
+from IPython import display
+from matplotlib import pyplot as plt
+
+d2l = sys.modules[__name__]
+
+import numpy as np
+import paddle

--- a/static/build.yml
+++ b/static/build.yml
@@ -2,7 +2,7 @@ dependencies:
   - python=3.8
   - pip
   - pip:
-    - d2l==0.17.4
+    - ..
     - git+https://github.com/d2l-ai/d2l-book
     - mxnet-cu102==1.7.0
     - torch==1.10.2+cu102


### PR DESCRIPTION
To use saved functions from paddle we need to build from source since d2l==0.17.4 or any d2l released version doesn't support the saved paddle methods.

This PR makes the necessary changes to build paddle from source and lib `d2l/paddle` for utilization of saved methods.

cc @cheungdaven @astonzhang  