### PR TITLE
Correct typo `nucleu` -> `nucleus` in §3.1.4.2

### DIFF
--- a/chapter_linear-networks/linear-regression.md
+++ b/chapter_linear-networks/linear-regression.md
@@ -462,7 +462,7 @@ $$-\log P(\mathbf y \mid \mathbf X) = \sum_{i=1}^n \frac{1}{2} \log(2 \pi \sigma
 他们为什么将线性模型作为一个起点呢？
 我们来看一张图片 :numref:`fig_Neuron`：
 这是一张由*树突*（dendrites，输入终端）、
-*细胞核*（nucleu，CPU）组成的生物神经元图片。
+*细胞核*（nucleus，CPU）组成的生物神经元图片。
 *轴突*（axon，输出线）和*轴突端子*（axon terminal，输出端子）
 通过*突触*（synapse）与其他神经元连接。
 


### PR DESCRIPTION
Correct a typo `nucleu` -> `nucleus` in [§3.1.4.2](https://zh.d2l.ai/chapter_linear-networks/linear-regression.html#id12).

Ref: ([English original](https://d2l.ai/chapter_linear-regression/linear-regression.html#biology))

> Consider the cartoonish picture of a biological neuron in [Fig. 3.1.3](https://d2l.ai/chapter_linear-regression/linear-regression.html#fig-neuron), consisting of *dendrites* (input terminals), the *nucleus* (CPU), the *axon* (output wire), and the *axon terminals* (output terminals), enabling connections to other neurons via *synapses*.
