### PR TITLE
[fix] Formula Error

### DIFF
--- a/chapter_preliminaries/calculus.md
+++ b/chapter_preliminaries/calculus.md
@@ -281,7 +281,7 @@ $$\frac{dy}{dx} = \frac{dy}{du} \frac{du}{dx}.$$
 注意，$y$是$x_1, x_2， \ldots, x_n$的函数。
 对于任意$i = 1, 2, \ldots, n$，链式法则给出：
 
-$$\frac{dy}{dx_i} = \frac{dy}{du_1} \frac{du_1}{dx_i} + \frac{dy}{du_2} \frac{du_2}{dx_i} + \cdots + \frac{dy}{du_m} \frac{du_m}{dx_i}$$
+$$\frac{\partial y}{\partial x_i} = \frac{\partial y}{\partial u_1} \frac{\partial u_1}{\partial x_i} + \frac{\partial y}{\partial u_2} \frac{\partial u_2}{\partial x_i} + \cdots + \frac{\partial y}{\partial u_m} \frac{\partial u_m}{\partial x_i}$$
 
 ## 小结
 


### PR DESCRIPTION
链式法则中，对于多元函数求微分，应该使用偏微分符号。
已对比英文版本并做出修改。