### PR TITLE
Missing point between "paddle" and "scatter" in Line 1484 and 1485.

### DIFF
--- a/d2l/paddle.py
+++ b/d2l/paddle.py
@@ -1481,8 +1481,8 @@ def split_batch(X, y, devices):
 
     Defined in :numref:`sec_multi_gpu`"""
     assert X.shape[0] == y.shape[0]
-    return (paddlescatter(X, devices),
-            paddlescatter(y, devices))
+    return (paddle.scatter(X, devices),
+            paddle.scatter(y, devices))
 
 def resnet18(num_classes, in_channels=1):
     """稍加修改的ResNet-18模型


### PR DESCRIPTION
It made the function `split_batch` throws a `NameError` Exception.