### PR TITLE
Fix(chapter_convolutional-modern): 修复BatchNorm实现中均值和方差无法通过 state_dict…

### DIFF
--- a/chapter_convolutional-modern/batch-norm.md
+++ b/chapter_convolutional-modern/batch-norm.md
@@ -261,8 +261,8 @@ class BatchNorm(nn.Module):
         self.gamma = nn.Parameter(torch.ones(shape))
         self.beta = nn.Parameter(torch.zeros(shape))
         # 非模型参数的变量初始化为0和1
-        self.moving_mean = torch.zeros(shape)
-        self.moving_var = torch.ones(shape)
+        self.register_buffer("moving_mean", torch.zeros(shape))
+        self.register_buffer("moving_var", torch.ones(shape))
 
     def forward(self, X):
         # 如果X不在内存上，将moving_mean和moving_var


### PR DESCRIPTION
… 保存的问题

使用register_buffer注册变量均值和方差使得均值和方差能够被state_dict保存。