### PR TITLE
Update d2l version

### DIFF
--- a/chapter_installation/index.md
+++ b/chapter_installation/index.md
@@ -127,7 +127,7 @@ python -m pip install paddlepaddle==2.3.2 -i https://pypi.tuna.tsinghua.edu.cn/s
 我们的下一步是安装`d2l`包，以方便调取本书中经常使用的函数和类：
 
 ```bash
-pip install d2l==0.17.6
+pip install d2l==1.0.0b0
 ```
 
 


### PR DESCRIPTION
update d2l version from 0.17.6 to 1.0.0b0, since 0.17.6 will cause a error as below when import d2l 
1.0.0b0 is working well

envs:
M2 macbook pro
python 3.9
torch==1.12.0
torchvision==0.13.0
d2l==0.17.6

```
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In[1], line 6
      4 import torch
      5 from torch import nn
----> 6 from d2l import torch as d2l

File ~/anaconda3/envs/d2l4/lib/python3.9/site-packages/d2l/torch.py:32
     30 import zipfile
     31 from collections import defaultdict
---> 32 import pandas as pd
     33 import requests
     34 from IPython import display

File ~/anaconda3/envs/d2l4/lib/python3.9/site-packages/pandas/__init__.py:29
     22 from pandas.compat.numpy import (
     23     np_version_under1p17 as _np_version_under1p17,
     24     np_version_under1p18 as _np_version_under1p18,
     25     is_numpy_dev as _is_numpy_dev,
     26 )
     28 try:
---> 29     from pandas._libs import hashtable as _hashtable, lib as _lib, tslib as _tslib
     30 except ImportError as e:  # pragma: no cover
     31     # hack but overkill to use re
     32     module = str(e).replace("cannot import name ", "")

File ~/anaconda3/envs/d2l4/lib/python3.9/site-packages/pandas/_libs/__init__.py:13
      1 __all__ = [
      2     "NaT",
      3     "NaTType",
   (...)
      9     "Interval",
     10 ]
---> 13 from pandas._libs.interval import Interval
     14 from pandas._libs.tslibs import (
     15     NaT,
     16     NaTType,
   (...)
     21     iNaT,
     22 )

File pandas/_libs/interval.pyx:1, in init pandas._libs.interval()

ValueError: numpy.ndarray size changed, may indicate binary incompatibility. Expected 96 from C header, got 88 from PyObject
```