### PR TITLE
Fix error of averaging on `string` values

### DIFF
--- a/chapter_preliminaries/pandas.md
+++ b/chapter_preliminaries/pandas.md
@@ -55,7 +55,7 @@ print(data)
 ```{.python .input}
 #@tab all
 inputs, outputs = data.iloc[:, 0:2], data.iloc[:, 2]
-inputs = inputs.fillna(inputs.mean())
+inputs = inputs.fillna(inputs.mean(numeric_only=True))
 print(inputs)
 ```
 

--- a/chapter_preliminaries/pandas_origin.md
+++ b/chapter_preliminaries/pandas_origin.md
@@ -64,7 +64,7 @@ we [**replace the "NaN" entries with the mean value of the same column.**]
 ```{.python .input}
 #@tab all
 inputs, outputs = data.iloc[:, 0:2], data.iloc[:, 2]
-inputs = inputs.fillna(inputs.mean())
+inputs = inputs.fillna(inputs.mean(numeric_only=True))
 print(inputs)
 ```
 


### PR DESCRIPTION
DataFrame's `mean()` method also calculates on `string` values, but adding `numeric_only=True` to the call fixed it.