### PR TITLE
3.7.1 softmax 公式推导问题

### DIFF
--- a/chapter_linear-networks/softmax-regression-concise.md
+++ b/chapter_linear-networks/softmax-regression-concise.md
@@ -115,8 +115,10 @@ $o_j$是未规范化的预测$\mathbf{o}$的第$j$个元素。
 
 $$
 \begin{aligned}
-\hat y_j & =  \frac{\exp(o_j - \max(o_k))\exp(\max(o_k))}{\sum_k \exp(o_k - \max(o_k))\exp(\max(o_k))} \\
-& = \frac{\exp(o_j - \max(o_k))}{\sum_k \exp(o_k - \max(o_k))}.
+\hat y_j & = \frac{\exp(o_j)}{\sum_k \exp(o_k)}\\
+&= \frac{\exp(o_j - \max(o_k))}{\sum_k \exp(o_k - \max(o_k))} \\
+& = \frac{\exp(o_j)\exp(\max(o_k))}{\sum_k \exp(o_k)\exp(\max(o_k))} \\
+& = \frac{\exp(o_j)}{\sum_k \exp(o_k)}.
 \end{aligned}
 $$
 


### PR DESCRIPTION
现公式没有很好地说明为什么每个 o_k 按常数进行的移动不会改变softmax的返回值：

<img width="868" alt="image" src="https://github.com/d2l-ai/d2l-zh/assets/8614151/8fa70c24-5df4-421a-9c79-911792689544">

建议修改为：

<img width="319" alt="image" src="https://github.com/d2l-ai/d2l-zh/assets/8614151/2c9dee58-0431-4fca-9f9d-4b58a8426dd3">
