### PR TITLE
fix: Fix the error in seq_data_iter_sequential function

### DIFF
--- a/chapter_recurrent-neural-networks/language-models-and-dataset.md
+++ b/chapter_recurrent-neural-networks/language-models-and-dataset.md
@@ -334,7 +334,7 @@ for X, Y in seq_data_iter_random(my_seq, batch_size=2, num_steps=5):
 def seq_data_iter_sequential(corpus, batch_size, num_steps):  #@save
     """使用顺序分区生成一个小批量子序列"""
     # 从随机偏移量开始划分序列
-    offset = random.randint(0, num_steps)
+    offset = random.randint(0, num_steps - 1)
     num_tokens = ((len(corpus) - offset - 1) // batch_size) * batch_size
     Xs = d2l.tensor(corpus[offset: offset + num_tokens])
     Ys = d2l.tensor(corpus[offset + 1: offset + 1 + num_tokens])
@@ -351,7 +351,7 @@ def seq_data_iter_sequential(corpus, batch_size, num_steps):  #@save
 def seq_data_iter_sequential(corpus, batch_size, num_steps):  #@save
     """使用顺序分区生成一个小批量子序列"""
     # 从随机偏移量开始划分序列
-    offset = random.randint(0, num_steps)
+    offset = random.randint(0, num_steps - 1)
     num_tokens = ((len(corpus) - offset - 1) // batch_size) * batch_size
     Xs = d2l.tensor(corpus[offset: offset + num_tokens])
     Ys = d2l.tensor(corpus[offset + 1: offset + 1 + num_tokens])
@@ -369,7 +369,7 @@ def seq_data_iter_sequential(corpus, batch_size, num_steps):  #@save
 def seq_data_iter_sequential(corpus, batch_size, num_steps):  #@save
     """使用顺序分区生成一个小批量子序列"""
     # 从随机偏移量开始划分序列
-    offset = random.randint(0, num_steps)
+    offset = random.randint(0, num_steps - 1)
     num_tokens = ((len(corpus) - offset - 1) // batch_size) * batch_size
     Xs = d2l.tensor(corpus[offset: offset + num_tokens])
     Ys = d2l.tensor(corpus[offset + 1: offset + 1 + num_tokens])

--- a/chapter_recurrent-neural-networks/language-models-and-dataset_origin.md
+++ b/chapter_recurrent-neural-networks/language-models-and-dataset_origin.md
@@ -333,7 +333,7 @@ This strategy preserves the order of split subsequences when iterating over mini
 def seq_data_iter_sequential(corpus, batch_size, num_steps):  #@save
     """Generate a minibatch of subsequences using sequential partitioning."""
     # Start with a random offset to partition a sequence
-    offset = random.randint(0, num_steps)
+    offset = random.randint(0, num_steps - 1)
     num_tokens = ((len(corpus) - offset - 1) // batch_size) * batch_size
     Xs = d2l.tensor(corpus[offset: offset + num_tokens])
     Ys = d2l.tensor(corpus[offset + 1: offset + 1 + num_tokens])
@@ -350,7 +350,7 @@ def seq_data_iter_sequential(corpus, batch_size, num_steps):  #@save
 def seq_data_iter_sequential(corpus, batch_size, num_steps):  #@save
     """Generate a minibatch of subsequences using sequential partitioning."""
     # Start with a random offset to partition a sequence
-    offset = random.randint(0, num_steps)
+    offset = random.randint(0, num_steps - 1)
     num_tokens = ((len(corpus) - offset - 1) // batch_size) * batch_size
     Xs = d2l.tensor(corpus[offset: offset + num_tokens])
     Ys = d2l.tensor(corpus[offset + 1: offset + 1 + num_tokens])

--- a/d2l/mxnet.py
+++ b/d2l/mxnet.py
@@ -609,7 +609,7 @@ def seq_data_iter_sequential(corpus, batch_size, num_steps):
 
     Defined in :numref:`sec_language_model`"""
     # 从随机偏移量开始划分序列
-    offset = random.randint(0, num_steps)
+    offset = random.randint(0, num_steps - 1)
     num_tokens = ((len(corpus) - offset - 1) // batch_size) * batch_size
     Xs = d2l.tensor(corpus[offset: offset + num_tokens])
     Ys = d2l.tensor(corpus[offset + 1: offset + 1 + num_tokens])

--- a/d2l/paddle.py
+++ b/d2l/paddle.py
@@ -670,7 +670,7 @@ def seq_data_iter_sequential(corpus, batch_size, num_steps):
 
     Defined in :numref:`sec_language_model`"""
     # 从随机偏移量开始划分序列
-    offset = random.randint(0, num_steps)
+    offset = random.randint(0, num_steps - 1)
     num_tokens = ((len(corpus) - offset - 1) // batch_size) * batch_size
     Xs = d2l.tensor(corpus[offset: offset + num_tokens])
     Ys = d2l.tensor(corpus[offset + 1: offset + 1 + num_tokens])

--- a/d2l/tensorflow.py
+++ b/d2l/tensorflow.py
@@ -629,7 +629,7 @@ def seq_data_iter_sequential(corpus, batch_size, num_steps):
 
     Defined in :numref:`sec_language_model`"""
     # 从随机偏移量开始划分序列
-    offset = random.randint(0, num_steps)
+    offset = random.randint(0, num_steps - 1)
     num_tokens = ((len(corpus) - offset - 1) // batch_size) * batch_size
     Xs = d2l.tensor(corpus[offset: offset + num_tokens])
     Ys = d2l.tensor(corpus[offset + 1: offset + 1 + num_tokens])

--- a/d2l/torch.py
+++ b/d2l/torch.py
@@ -657,7 +657,7 @@ def seq_data_iter_sequential(corpus, batch_size, num_steps):
 
     Defined in :numref:`sec_language_model`"""
     # 从随机偏移量开始划分序列
-    offset = random.randint(0, num_steps)
+    offset = random.randint(0, num_steps - 1)
     num_tokens = ((len(corpus) - offset - 1) // batch_size) * batch_size
     Xs = d2l.tensor(corpus[offset: offset + num_tokens])
     Ys = d2l.tensor(corpus[offset + 1: offset + 1 + num_tokens])


### PR DESCRIPTION
Fix the `seq_data_iter_sequential` function so that the `offset` variable cannot take on the value of `num_steps`, because the `random.randint` function can include both endpoints.  
from `offset = random.randint(0, num_steps)` change to `offset = random.randint(0, num_steps - 1)`