### PR TITLE
add emptyset symbol in index.md of chapter_notation

### DIFF
--- a/chapter_notation/index.md
+++ b/chapter_notation/index.md
@@ -16,6 +16,7 @@
 ## 集合论
 
 * $\mathcal{X}$: 集合
+* $\emptyset$: 空集
 * $\mathbb{Z}$: 整数集合
 * $\mathbb{R}$: 实数集合
 * $\mathbb{R}^n$: $n$维实数向量集合


### PR DESCRIPTION
Because the `probability.md` file in the `chapter_preliminaries` 
 uses the empty set symbol.