### PR TITLE
更新 pandas.md。对高版本Pandas库适配

### DIFF
--- a/chapter_preliminaries/pandas.md
+++ b/chapter_preliminaries/pandas.md
@@ -55,7 +55,7 @@ print(data)
 ```{.python .input}
 #@tab all
 inputs, outputs = data.iloc[:, 0:2], data.iloc[:, 2]
-inputs = inputs.fillna(inputs.mean())
+inputs = inputs.fillna(inputs.select_dtypes(include='number').mean())
 print(inputs)
 ```
 


### PR DESCRIPTION
由于旧版Pandas库在对inputs执行mean()方法时，会跳过不可计算的类型，从而忽略报错直接计算出数据；而高版本pandas库会对数据类型进行严格检查，从而触发报错“TypeError: can only concatenate str (not "int") to str”。修正后的代码将对数据类型进行筛选并计算，规避报错内容