### PR TITLE
fix offset

### DIFF
--- a/chapter_recurrent-neural-networks/language-models-and-dataset.md
+++ b/chapter_recurrent-neural-networks/language-models-and-dataset.md
@@ -334,7 +334,7 @@ for X, Y in seq_data_iter_random(my_seq, batch_size=2, num_steps=5):
 def seq_data_iter_sequential(corpus, batch_size, num_steps):  #@save
     """使用顺序分区生成一个小批量子序列"""
     # 从随机偏移量开始划分序列
-    offset = random.randint(0, num_steps)
+    offset = random.randint(0, num_steps - 1)
     num_tokens = ((len(corpus) - offset - 1) // batch_size) * batch_size
     Xs = d2l.tensor(corpus[offset: offset + num_tokens])
     Ys = d2l.tensor(corpus[offset + 1: offset + 1 + num_tokens])
@@ -351,7 +351,7 @@ def seq_data_iter_sequential(corpus, batch_size, num_steps):  #@save
 def seq_data_iter_sequential(corpus, batch_size, num_steps):  #@save
     """使用顺序分区生成一个小批量子序列"""
     # 从随机偏移量开始划分序列
-    offset = random.randint(0, num_steps)
+    offset = random.randint(0, num_steps - 1)
     num_tokens = ((len(corpus) - offset - 1) // batch_size) * batch_size
     Xs = d2l.tensor(corpus[offset: offset + num_tokens])
     Ys = d2l.tensor(corpus[offset + 1: offset + 1 + num_tokens])
@@ -369,7 +369,7 @@ def seq_data_iter_sequential(corpus, batch_size, num_steps):  #@save
 def seq_data_iter_sequential(corpus, batch_size, num_steps):  #@save
     """使用顺序分区生成一个小批量子序列"""
     # 从随机偏移量开始划分序列
-    offset = random.randint(0, num_steps)
+    offset = random.randint(0, num_steps - 1)
     num_tokens = ((len(corpus) - offset - 1) // batch_size) * batch_size
     Xs = d2l.tensor(corpus[offset: offset + num_tokens])
     Ys = d2l.tensor(corpus[offset + 1: offset + 1 + num_tokens])

--- a/chapter_recurrent-neural-networks/language-models-and-dataset_origin.md
+++ b/chapter_recurrent-neural-networks/language-models-and-dataset_origin.md
@@ -283,7 +283,7 @@ in each subsequence.
 def seq_data_iter_random(corpus, batch_size, num_steps):  #@save
     """Generate a minibatch of subsequences using random sampling."""
     # Start with a random offset to partition a sequence
-    corpus = corpus[random.randint(0, num_steps):]
+    corpus = corpus[random.randint(0, num_steps - 1):]
     # Subtract 1 since we need to account for labels
     num_subseqs = (len(corpus) - 1) // num_steps
     # The starting indices for subsequences of length `num_steps`
@@ -333,7 +333,7 @@ This strategy preserves the order of split subsequences when iterating over mini
 def seq_data_iter_sequential(corpus, batch_size, num_steps):  #@save
     """Generate a minibatch of subsequences using sequential partitioning."""
     # Start with a random offset to partition a sequence
-    offset = random.randint(0, num_steps)
+    offset = random.randint(0, num_steps - 1)
     num_tokens = ((len(corpus) - offset - 1) // batch_size) * batch_size
     Xs = d2l.tensor(corpus[offset: offset + num_tokens])
     Ys = d2l.tensor(corpus[offset + 1: offset + 1 + num_tokens])
@@ -350,7 +350,7 @@ def seq_data_iter_sequential(corpus, batch_size, num_steps):  #@save
 def seq_data_iter_sequential(corpus, batch_size, num_steps):  #@save
     """Generate a minibatch of subsequences using sequential partitioning."""
     # Start with a random offset to partition a sequence
-    offset = random.randint(0, num_steps)
+    offset = random.randint(0, num_steps - 1)
     num_tokens = ((len(corpus) - offset - 1) // batch_size) * batch_size
     Xs = d2l.tensor(corpus[offset: offset + num_tokens])
     Ys = d2l.tensor(corpus[offset + 1: offset + 1 + num_tokens])

--- a/d2l/mxnet.py
+++ b/d2l/mxnet.py
@@ -609,7 +609,7 @@ def seq_data_iter_sequential(corpus, batch_size, num_steps):
 
     Defined in :numref:`sec_language_model`"""
     # 从随机偏移量开始划分序列
-    offset = random.randint(0, num_steps)
+    offset = random.randint(0, num_steps - 1)
     num_tokens = ((len(corpus) - offset - 1) // batch_size) * batch_size
     Xs = d2l.tensor(corpus[offset: offset + num_tokens])
     Ys = d2l.tensor(corpus[offset + 1: offset + 1 + num_tokens])

--- a/d2l/paddle.py
+++ b/d2l/paddle.py
@@ -670,7 +670,7 @@ def seq_data_iter_sequential(corpus, batch_size, num_steps):
 
     Defined in :numref:`sec_language_model`"""
     # 从随机偏移量开始划分序列
-    offset = random.randint(0, num_steps)
+    offset = random.randint(0, num_steps - 1)
     num_tokens = ((len(corpus) - offset - 1) // batch_size) * batch_size
     Xs = d2l.tensor(corpus[offset: offset + num_tokens])
     Ys = d2l.tensor(corpus[offset + 1: offset + 1 + num_tokens])

--- a/d2l/tensorflow.py
+++ b/d2l/tensorflow.py
@@ -629,7 +629,7 @@ def seq_data_iter_sequential(corpus, batch_size, num_steps):
 
     Defined in :numref:`sec_language_model`"""
     # 从随机偏移量开始划分序列
-    offset = random.randint(0, num_steps)
+    offset = random.randint(0, num_steps - 1)
     num_tokens = ((len(corpus) - offset - 1) // batch_size) * batch_size
     Xs = d2l.tensor(corpus[offset: offset + num_tokens])
     Ys = d2l.tensor(corpus[offset + 1: offset + 1 + num_tokens])

--- a/d2l/torch.py
+++ b/d2l/torch.py
@@ -657,7 +657,7 @@ def seq_data_iter_sequential(corpus, batch_size, num_steps):
 
     Defined in :numref:`sec_language_model`"""
     # 从随机偏移量开始划分序列
-    offset = random.randint(0, num_steps)
+    offset = random.randint(0, num_steps - 1)
     num_tokens = ((len(corpus) - offset - 1) // batch_size) * batch_size
     Xs = d2l.tensor(corpus[offset: offset + num_tokens])
     Ys = d2l.tensor(corpus[offset + 1: offset + 1 + num_tokens])


### PR DESCRIPTION
在 [8.3.4.2. 顺序分区](https://zh.d2l.ai/chapter_recurrent-neural-networks/language-models-and-dataset.html#id7) 中，offset 应赋值为

```
offset = random.randint(0, num_steps - 1)
```

而非

```
offset = random.randint(0, num_steps)
```

我们注意到，`random.randint(0, num_steps)` 的可能取值是包含 0 和 num_steps 的。比如当 `num_steps = 3` 时，offset 被赋值为 `random.randint(0, 3)`，此时 offset 的可能取值为：0, 1, 2, 3。

在这里，offset 取 0 和 3 是等效的，都代表偏移量为 0。为避免浪费 token，offset 最好赋值为 `random.randint(0, num_steps - 1)`，这样能最大程度利用 corpus 序列（否则当 offset 正好取到 num_steps 时会浪费一个序列）。

> **Note**: 这里正好有一个容易混淆的点，就是 offset 赋值的下一行是
> 
> `num_tokens = ((len(corpus) - offset - 1) // batch_size) * batch_size`
>
> 里面正好包含了一个 `offset - 1`，一开始我以为上面漏减的在这里补减了，往后看发现不是，这里减 1 的原因是，标号 (y label) 的序列与 x 的序列有长度为 1 的偏移，这里是为了保证 y label 不会取到数组右侧边界之外，才减的 1，才不是为上一行补减的 (・ω< )★