### PR TITLE
Fix a typo in resnet.md

### DIFF
--- a/chapter_convolutional-modern/resnet.md
+++ b/chapter_convolutional-modern/resnet.md
@@ -330,7 +330,7 @@ class ResnetBlock(tf.keras.layers.Layer):
                 self.residual_layers.append(Residual(num_channels))
 
     def call(self, X):
-        for layer in self.residual_layers.layers:
+        for layer in self.residual_layers:
             X = layer(X)
         return X
 ```


### PR DESCRIPTION
The code in ResnetBlock.call() contains a for-loop, where an extra `.layers` seems like a typo. By removing it the code works for me locally.