### PR TITLE
修改了“softmax回归的从零开始实现”中的一个公式错误

### DIFF
--- a/chapter_linear-networks/softmax-regression-scratch.md
+++ b/chapter_linear-networks/softmax-regression-scratch.md
@@ -130,7 +130,7 @@ d2l.reduce_sum(X, 0, keepdims=True), d2l.reduce_sum(X, 1, keepdims=True)
 
 (**
 $$
-\mathrm{softmax}(\mathbf{X})_{ij} = \frac{\exp(\mathbf{X}_{ij})}{\sum_k \exp(\mathbf{X}_{ik})}.
+\mathrm{softmax}(\mathbf{X_{ij}}) = \frac{\exp(\mathbf{X}_{ij})}{\sum_k \exp(\mathbf{X}_{ik})}.
 $$
 **)
 


### PR DESCRIPTION
公式：
$$
\mathrm{softmax}(\mathbf{X})_{ij} = \frac{\exp(\mathbf{X}_{ij})}{\sum_k \exp(\mathbf{X}_{ik})}. $$
中，我认为softmax的参数$X$下标ij应该在括号里面，这样表示$X_ij$在该行所有元素中的softmax值。