### PR TITLE
Update padding-and-strides_origin.md

### DIFF
--- a/chapter_convolutional-neural-networks/padding-and-strides_origin.md
+++ b/chapter_convolutional-neural-networks/padding-and-strides_origin.md
@@ -239,11 +239,11 @@ there is no output because the input element cannot fill the window
 In general, when the stride for the height is $s_h$
 and the stride for the width is $s_w$, the output shape is
 
-$$\lfloor(n_h-k_h+p_h+s_h)/s_h\rfloor \times \lfloor(n_w-k_w+p_w+s_w)/s_w\rfloor.$$
+$$\lceil(n_h-k_h+p_h+s_h)/s_h\rceil \times \lceil(n_w-k_w+p_w+s_w)/s_w\rceil.$$
 
 If we set $p_h=k_h-1$ and $p_w=k_w-1$,
 then the output shape will be simplified to
-$\lfloor(n_h+s_h-1)/s_h\rfloor \times \lfloor(n_w+s_w-1)/s_w\rfloor$.
+$\lceil(n_h+s_h-1)/s_h\rceil \times \lceil(n_w+s_w-1)/s_w\rceil$.
 Going a step further, if the input height and width
 are divisible by the strides on the height and width,
 then the output shape will be $(n_h/s_h) \times (n_w/s_w)$.


### PR DESCRIPTION
I think the formula should change \lfloor and \rfloor to \lceil and \rceil. For example, if an (5x5) input performing convolution operation, and the kernel has size of 3x3, strides is 2, the output should be (2x2), but if use "round down", the result is 1x1, we could get right answer if we use "round up". And if we use the kernel has same size with input, and no padding, strides is 1, the output is 0x0 if we use "round down",but we know it must be 1x1, "round down" could solve this problem. If my thought has any wrong, hope you could tell me, thanks.