### PR TITLE
Update anchor.md

### DIFF
--- a/chapter_computer-vision/anchor.md
+++ b/chapter_computer-vision/anchor.md
@@ -412,7 +412,7 @@ def box_iou(boxes1, boxes2):
 ```{.python .input}
 #@save
 def assign_anchor_to_bbox(ground_truth, anchors, device, iou_threshold=0.5):
-    """将最接近的真实边界框分配给锚框"""
+    """将最接近的锚框分配给真实边界框"""
     num_anchors, num_gt_boxes = anchors.shape[0], ground_truth.shape[0]
     # 位于第i行和第j列的元素x_ij是锚框i和真实边界框j的IoU
     jaccard = box_iou(anchors, ground_truth)
@@ -439,7 +439,7 @@ def assign_anchor_to_bbox(ground_truth, anchors, device, iou_threshold=0.5):
 #@tab pytorch
 #@save
 def assign_anchor_to_bbox(ground_truth, anchors, device, iou_threshold=0.5):
-    """将最接近的真实边界框分配给锚框"""
+    """将最接近的锚框分配给真实边界框"""
     num_anchors, num_gt_boxes = anchors.shape[0], ground_truth.shape[0]
     # 位于第i行和第j列的元素x_ij是锚框i和真实边界框j的IoU
     jaccard = box_iou(anchors, ground_truth)


### PR DESCRIPTION
根据本节的算法，每找到一个真实边框最近的锚框，就丢弃对应交并比所在列和行的所有元素。于是，所有真实值都有一个锚框，而有部分锚框没有被分配。根据中文语境和算法流程，应是“将最接近的锚框分配给真实边界框”，若是原始注释，则所有锚框应该都被分配。故建议修改

![image](https://github.com/user-attachments/assets/8a5f5a21-14d4-468e-9f10-b5e563ecc47d)
