### PR TITLE
Update seq2seq.md

### DIFF
--- a/chapter_recurrent-modern/seq2seq.md
+++ b/chapter_recurrent-modern/seq2seq.md
@@ -724,7 +724,7 @@ def train_seq2seq(net, data_iter, lr, num_epochs, tgt_vocab, device):
                        ctx=device).reshape(-1, 1)
             dec_input = np.concatenate([bos, Y[:, :-1]], 1)  # 强制教学
             with autograd.record():
-                Y_hat, _ = net(X, dec_input, X_valid_len)
+                Y_hat = net(X, dec_input, X_valid_len)
                 l = loss(Y_hat, Y, Y_valid_len)
             l.backward()
             d2l.grad_clipping(net, 1)
@@ -766,7 +766,7 @@ def train_seq2seq(net, data_iter, lr, num_epochs, tgt_vocab, device):
             bos = torch.tensor([tgt_vocab['<bos>']] * Y.shape[0],
                           device=device).reshape(-1, 1)
             dec_input = torch.cat([bos, Y[:, :-1]], 1)  # 强制教学
-            Y_hat, _ = net(X, dec_input, X_valid_len)
+            Y_hat = net(X, dec_input, X_valid_len)
             l = loss(Y_hat, Y, Y_valid_len)
             l.sum().backward()	# 损失函数的标量进行“反向传播”
             d2l.grad_clipping(net, 1)
@@ -797,7 +797,7 @@ def train_seq2seq(net, data_iter, lr, num_epochs, tgt_vocab, device):
                              shape=(-1, 1))
             dec_input = tf.concat([bos, Y[:, :-1]], 1)  # 强制教学
             with tf.GradientTape() as tape:
-                Y_hat, _ = net(X, dec_input, X_valid_len, training=True)
+                Y_hat = net(X, dec_input, X_valid_len, training=True)
                 l = MaskedSoftmaxCELoss(Y_valid_len)(Y, Y_hat)
             gradients = tape.gradient(l, net.trainable_variables)
             gradients = d2l.grad_clipping(gradients, 1)


### PR DESCRIPTION
根据新版d2l中class EncoderDecoder的定义[1]，其返回值只有一个，因此建议将“_”删除，否则会报错：ValueError: too many values to unpack (expected 2)
[1] https://github.com/d2l-ai/d2l-en/blob/master/d2l/torch.py#L951
修改前
![image](https://github.com/user-attachments/assets/7266bf0b-989e-48bb-9531-6b6f9acec931)
修改后
![image](https://github.com/user-attachments/assets/de569c41-1697-41a1-bde1-59ff20c76681)
