### PR TITLE
修改 num_workers 和文件 seq2seq.md

### DIFF
--- a/chapter_computer-vision/semantic-segmentation-and-dataset.md
+++ b/chapter_computer-vision/semantic-segmentation-and-dataset.md
@@ -447,7 +447,7 @@ voc_test = VOCSegDataset(False, crop_size, voc_dir)
 batch_size = 64
 train_iter = gluon.data.DataLoader(voc_train, batch_size, shuffle=True,
                                    last_batch='discard',
-                                   num_workers=d2l.get_dataloader_workers())
+                                   num_workers=0)
 for X, Y in train_iter:
     print(X.shape)
     print(Y.shape)
@@ -459,7 +459,7 @@ for X, Y in train_iter:
 batch_size = 64
 train_iter = torch.utils.data.DataLoader(voc_train, batch_size, shuffle=True,
                                     drop_last=True,
-                                    num_workers=d2l.get_dataloader_workers())
+                                    num_workers=0)
 for X, Y in train_iter:
     print(X.shape)
     print(Y.shape)
@@ -472,7 +472,7 @@ batch_size = 64
 train_iter = paddle.io.DataLoader(voc_train, batch_size=batch_size, shuffle=True,
                                   drop_last=True,
                                   return_list=True,
-                                  num_workers=d2l.get_dataloader_workers())
+                                  num_workers=0)
 for X, Y in train_iter:
     print(X.shape)
     print(Y.shape)
@@ -490,7 +490,7 @@ def load_data_voc(batch_size, crop_size):
     """加载VOC语义分割数据集"""
     voc_dir = d2l.download_extract('voc2012', os.path.join(
         'VOCdevkit', 'VOC2012'))
-    num_workers = d2l.get_dataloader_workers()
+    num_workers = 0
     train_iter = gluon.data.DataLoader(
         VOCSegDataset(True, crop_size, voc_dir), batch_size,
         shuffle=True, last_batch='discard', num_workers=num_workers)
@@ -507,7 +507,7 @@ def load_data_voc(batch_size, crop_size):
     """加载VOC语义分割数据集"""
     voc_dir = d2l.download_extract('voc2012', os.path.join(
         'VOCdevkit', 'VOC2012'))
-    num_workers = d2l.get_dataloader_workers()
+    num_workers = 0
     train_iter = torch.utils.data.DataLoader(
         VOCSegDataset(True, crop_size, voc_dir), batch_size,
         shuffle=True, drop_last=True, num_workers=num_workers)
@@ -524,7 +524,7 @@ def load_data_voc(batch_size, crop_size):
     """加载VOC语义分割数据集"""
     voc_dir = d2l.download_extract('voc2012', os.path.join(
         'VOCdevkit', 'VOC2012'))
-    num_workers = d2l.get_dataloader_workers()
+    num_workers = 0
     train_iter = paddle.io.DataLoader(
         VOCSegDataset(True, crop_size, voc_dir), batch_size=batch_size,
         shuffle=True, return_list=True, drop_last=True, num_workers=num_workers)

--- a/chapter_computer-vision/semantic-segmentation-and-dataset_origin.md
+++ b/chapter_computer-vision/semantic-segmentation-and-dataset_origin.md
@@ -383,7 +383,7 @@ Different from in image classification or object detection, labels here are thre
 batch_size = 64
 train_iter = gluon.data.DataLoader(voc_train, batch_size, shuffle=True,
                                    last_batch='discard',
-                                   num_workers=d2l.get_dataloader_workers())
+                                   num_workers=0)
 for X, Y in train_iter:
     print(X.shape)
     print(Y.shape)
@@ -395,7 +395,7 @@ for X, Y in train_iter:
 batch_size = 64
 train_iter = torch.utils.data.DataLoader(voc_train, batch_size, shuffle=True,
                                     drop_last=True,
-                                    num_workers=d2l.get_dataloader_workers())
+                                    num_workers=0)
 for X, Y in train_iter:
     print(X.shape)
     print(Y.shape)
@@ -414,7 +414,7 @@ def load_data_voc(batch_size, crop_size):
     """Load the VOC semantic segmentation dataset."""
     voc_dir = d2l.download_extract('voc2012', os.path.join(
         'VOCdevkit', 'VOC2012'))
-    num_workers = d2l.get_dataloader_workers()
+    num_workers = 0
     train_iter = gluon.data.DataLoader(
         VOCSegDataset(True, crop_size, voc_dir), batch_size,
         shuffle=True, last_batch='discard', num_workers=num_workers)
@@ -431,7 +431,7 @@ def load_data_voc(batch_size, crop_size):
     """Load the VOC semantic segmentation dataset."""
     voc_dir = d2l.download_extract('voc2012', os.path.join(
         'VOCdevkit', 'VOC2012'))
-    num_workers = d2l.get_dataloader_workers()
+    num_workers = 0
     train_iter = torch.utils.data.DataLoader(
         VOCSegDataset(True, crop_size, voc_dir), batch_size,
         shuffle=True, drop_last=True, num_workers=num_workers)

--- a/chapter_recurrent-modern/seq2seq.md
+++ b/chapter_recurrent-modern/seq2seq.md
@@ -609,17 +609,20 @@ class MaskedSoftmaxCELoss(gluon.loss.SoftmaxCELoss):
 ```{.python .input}
 #@tab pytorch
 #@save
-class MaskedSoftmaxCELoss(nn.CrossEntropyLoss):
+class MaskedSoftmaxCELoss(nn.Module):
     """带遮蔽的softmax交叉熵损失函数"""
     # pred的形状：(batch_size,num_steps,vocab_size)
     # label的形状：(batch_size,num_steps)
     # valid_len的形状：(batch_size,)
+    def __init__(self, **kwargs):
+        super(MaskedSoftmaxCELoss, self).__init__(**kwargs)
+        # 初始化 nn.CrossEntropyLoss 作为类的成员
+        # reduction='none' 确保返回的是未聚合的逐元素损失，方便遮蔽
+        self.cross_entropy = nn.CrossEntropyLoss(reduction='none')
     def forward(self, pred, label, valid_len):
         weights = torch.ones_like(label)
         weights = sequence_mask(weights, valid_len)
-        self.reduction='none'
-        unweighted_loss = super(MaskedSoftmaxCELoss, self).forward(
-            pred.permute(0, 2, 1), label)
+        unweighted_loss = self.cross_entropy(pred.permute(0, 2, 1), label)
         weighted_loss = (unweighted_loss * weights).mean(dim=1)
         return weighted_loss
 ```


### PR DESCRIPTION
当 num_workers > 0时，每个子进程都会完整地读取整个数据集。这导致数据集被多次加载，浪费了计算资源，并且在运行时显示了重复的输出。而且在Windows上使用multiprocessing模块时，子进程的创建必须在if __name__ == '__main__':的保护下进行。建议num_workers修改为0。


在文件seq2seq中，使用 super(MaskedSoftmaxCELoss, self).forward(...) 调用基类的 forward 方法时，由于 forward 方法多了一个 valid_len 参数，这导致了签名不匹配的警告。因此不直接继承 nn.CrossEntropyLoss 并重写其 forward 方法，而是将 nn.CrossEntropyLoss 作为 MaskedSoftmaxCELoss 类的一个内部成员，并在其 forward 方法中调用内部 CrossEntropyLoss 实例的 forward 方法。