### PR TITLE
fix pandas error in newer version of it

### DIFF
--- a/chapter_preliminaries/pandas.md
+++ b/chapter_preliminaries/pandas.md
@@ -55,7 +55,7 @@ print(data)
 ```{.python .input}
 #@tab all
 inputs, outputs = data.iloc[:, 0:2], data.iloc[:, 2]
-inputs = inputs.fillna(inputs.mean())
+inputs = inputs.fillna(inputs.mean(numeric_only=True))
 print(inputs)
 ```
 
@@ -67,7 +67,7 @@ print(inputs)
 
 ```{.python .input}
 #@tab all
-inputs = pd.get_dummies(inputs, dummy_na=True)
+inputs = pd.get_dummies(inputs, dummy_na=True, dtype=int)
 print(inputs)
 ```
 


### PR DESCRIPTION
In newer version of pandas, the origin code would generate errors and unexpected behavior. In order to fix it, more params should be passed in both `inputs.mean()` and `pd.get_nummies()`.